### PR TITLE
fix: glob pattern

### DIFF
--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -6,7 +6,7 @@ executor: default
 parameters:
   glob:
     type: string
-    default: "**/*.{md,adoc}"
+    default: "*.{md,adoc}"
     description: "Glob pattern to match files against. By default, all markdown and AsciiDoc files will be linted."
   base_dir:
     type: string


### PR DESCRIPTION
## Changes

The current default glob, `**/*.{md,adoc}`, misses files in the root directory. This PR addresses that by changing it to `*.{md,adoc}`.