### PR TITLE
fix: path resolution

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -25,7 +25,17 @@ workflows:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       # Test your orb's commands in a custom job and test your orb's jobs directly as a part of this workflow.
       - vale/lint:
+          name: vale-lint-all
           base_dir: "sample/"
+          filters: *filters
+      - vale/lint:
+          name: vale-lint-md
+          base_dir: "sample/"
+          glob: "*/test.md"
+          filters: *filters
+      - vale/lint:
+          name: vale-lint-readme
+          glob: "*/README.md"
           filters: *filters
       # The orb must be re-packed for publishing, and saved to the workspace.
       - orb-tools/pack:
@@ -37,7 +47,8 @@ workflows:
           # Ensure this job requires all test jobs and the pack job.
           requires:
             - orb-tools/pack
-            - vale/lint
+            - vale-lint-all
+            - vale-lint-md
           context: orb-publisher
           github_token: GHI_TOKEN
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -49,6 +49,7 @@ workflows:
             - orb-tools/pack
             - vale-lint-all
             - vale-lint-md
+            - vale-lint-readme
           context: orb-publisher
           github_token: GHI_TOKEN
           filters: *release-filters

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A CircleCI orb for [Vale](https://github.com/errata-ai/vale) from [errata.ai](ht
 ---
 ### How to Contribute
 
-We welcome [issues](https://github.com/CircleCI-Public/vale-orb/issues) to and [pull requests](https://github.com/CircleCI-Public/vale-orb/pulls) against this repository!
+We welcome [issues](https://github.com/CircleCI-Public/vale-orb/issues) to and [pull requests](https://github.com/CircleCI-Public/vale-orb/pulls) against this repository.
 
 ### How to Publish An Update
 1. Merge pull requests with desired changes to the main branch.

--- a/sample/sample-subdirectory/test.adoc
+++ b/sample/sample-subdirectory/test.adoc
@@ -1,0 +1,39 @@
+= Document Title
+Doc Writer <doc@example.com>
+:reproducible:
+:listing-caption: Listing
+:source-highlighter: rouge
+:toc:
+// Uncomment next line to add a title page (or set doctype to book)
+//:title-page:
+// Uncomment next line to set page size (default is A4)
+//:pdf-page-size: Letter
+
+An example of a basic https://asciidoc.org[AsciiDoc] document prepared by {author}.
+
+== Introduction
+
+A paragraph followed by an unordered list{empty}footnote:[AsciiDoc supports unordered, ordered, and description lists.] with square bullets.footnote:[You may choose from square, disc, and circle for the bullet style.]
+
+[square]
+* item 1
+* item 2
+* item 3
+
+== Main
+
+Here's how you say "`Hello, World.`" in Prawn:
+
+.Create a basic PDF document using Prawn
+[source,ruby]
+----
+require 'prawn'
+
+Prawn::Document.generate 'example.pdf' do
+  text 'Hello, World.'
+end
+----
+
+== Conclusion
+
+That's all, folks.

--- a/sample/sample-subdirectory/test.html
+++ b/sample/sample-subdirectory/test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test</title>
+  </head>
+  <body>
+    <h1>Test</h1>
+    <p>This is a sample document in HTML.</p>
+  </body>
+</html>

--- a/sample/sample-subdirectory/test.md
+++ b/sample/sample-subdirectory/test.md
@@ -1,0 +1,8 @@
+author: circleci
+tags: [circleci, test]
+title: Test
+---
+
+# Test
+
+This is a sample document for testing the Vale CLI.

--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@ The default `.circleci/config.yml` file contains the configuration code needed t
 
 ## @orb.yml
 
-This is the entry point for our orb "tree", which becomes our `orb.yml` file later.
+This is the entry point for our orb "tree," which becomes our `orb.yml` file later.
 
 Within the `@orb.yml` we generally specify 4 configuration keys
 

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -10,7 +10,7 @@ parameters:
     description: "Glob pattern to match files against. By default, all markdown and AsciiDoc files will be linted."
   base_dir:
     type: string
-    default: "."
+    default: "$CIRCLE_WORKING_DIRECTORY"
     description: "Base directory to run Vale from. By default, Vale will run in the current directory."
   config:
     type: string

--- a/src/scripts/lint.sh
+++ b/src/scripts/lint.sh
@@ -6,7 +6,9 @@ redtext() {
 
 VALE_EVAL_CLI_CONFIG="$(eval echo "$VALE_EVAL_CLI_CONFIG")"
 VALE_STR_CLI_GLOB="$(circleci env subst "$VALE_STR_CLI_GLOB")"
+
 VALE_EVAL_CLI_BASE_DIR="$(eval echo "$VALE_EVAL_CLI_BASE_DIR")"
+VALE_EVAL_CLI_BASE_DIR="${VALE_EVAL_CLI_BASE_DIR/\~/$HOME}"
 
 if [[ ! -f "$VALE_EVAL_CLI_CONFIG" ]]; then
   redtext "No configuration file found at $VALE_EVAL_CLI_CONFIG"

--- a/src/scripts/lint.sh
+++ b/src/scripts/lint.sh
@@ -23,6 +23,5 @@ if [[ ! -f "$VALE_EVAL_CLI_CONFIG" ]]; then
 fi
 set -x
 vale sync
-# shellcheck disable=SC2086
-vale --glob="$VALE_STR_CLI_GLOB" --config="$VALE_EVAL_CLI_CONFIG" $VALE_EVAL_CLI_BASE_DIR
+vale --glob="$VALE_STR_CLI_GLOB" --config="$VALE_EVAL_CLI_CONFIG" "$VALE_EVAL_CLI_BASE_DIR"
 set +x

--- a/src/scripts/lint.sh
+++ b/src/scripts/lint.sh
@@ -21,5 +21,6 @@ if [[ ! -f "$VALE_EVAL_CLI_CONFIG" ]]; then
 fi
 set -x
 vale sync
-vale --glob="$VALE_STR_CLI_GLOB" --config="$VALE_EVAL_CLI_CONFIG" "$VALE_EVAL_CLI_BASE_DIR"
+# shellcheck disable=SC2086
+vale --glob="$VALE_STR_CLI_GLOB" --config="$VALE_EVAL_CLI_CONFIG" $VALE_EVAL_CLI_BASE_DIR
 set +x

--- a/styles/Vocab/CircleCI/accept.txt
+++ b/styles/Vocab/CircleCI/accept.txt
@@ -1,1 +1,2 @@
 circleci
+CircleCI


### PR DESCRIPTION
## Changes

- Replace the default base path with `$CIRCLE_WORKING_DIRECTORY`.
- Manually replace the tilde `~` with the content from `$HOME` to avoid errors with the Vale CLI.
- Add a subdirectory with files in `samples` to test how the glob reacts to nested files.
- Include a test to check globs for named files (e.g., `*/test.md`).
- Add a test for files in the root directory.