### PR TITLE
feat: check only modified files

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -27,14 +27,17 @@ workflows:
       - vale/lint:
           name: vale-lint-all
           base_dir: "sample/"
+          strategy: all
           filters: *filters
       - vale/lint:
           name: vale-lint-md
           base_dir: "sample/"
+          strategy: all
           glob: "*/test.md"
           filters: *filters
       - vale/lint:
           name: vale-lint-readme
+          strategy: all
           glob: "*/README.md"
           filters: *filters
       # The orb must be re-packed for publishing, and saved to the workspace.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # orb.yml is "packed" from source, and not published directly from the repository.
 orb.yml
 .DS_Store
+styles/Google
+styles/write-good

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -16,12 +16,23 @@ parameters:
     type: string
     default: ".vale.ini"
     description: "Path to a Vale configuration file. By default, Vale will look for a .vale.ini file in the root of your repository."
+  strategy:
+    type: enum
+    default: modified
+    enum: [modified, all]
+    description: "Strategy to use when determining which files to lint. By default, only modified files will be linted."
+  reference_branch:
+    type: string
+    default: main
+    description: "Branch to use as a reference when determining modified files. By default, the main branch will be used."
 steps:
   - checkout
   - run:
       name: Lint files
       environment:
         VALE_STR_CLI_GLOB: << parameters.glob >>
+        VALE_STR_REFERENCE_BRANCH: << parameters.reference_branch >>
         VALE_EVAL_CLI_CONFIG: << parameters.config >>
         VALE_EVAL_CLI_BASE_DIR: << parameters.base_dir >>
+        VALE_ENUM_STRATEGY: << parameters.strategy >>
       command: <<include(scripts/lint.sh)>>

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -20,11 +20,17 @@ parameters:
     type: enum
     default: modified
     enum: [modified, all]
-    description: "Strategy to use when determining which files to lint. By default, only modified files will be linted."
+    description: |
+      Strategy to use when determining which files to lint. 
+      By default, only modified files will be linted.
+      If set to modified, the "reference_branch" parameter must also be set.
   reference_branch:
     type: string
     default: main
-    description: "Branch to use as a reference when determining modified files. By default, the main branch will be used."
+    description: |
+      Branch to use as a reference when determining modified files. 
+      By default, the main branch will be used.
+      If the "strategy" is set to modified, this parameter must also be set.
 steps:
   - checkout
   - run:

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -21,16 +21,16 @@ parameters:
     default: modified
     enum: [modified, all]
     description: |
-      Strategy to use when determining which files to lint. 
+      Strategy to use when determining which files to lint.
       By default, only modified files will be linted.
       If set to modified, the "reference_branch" parameter must also be set.
   reference_branch:
     type: string
     default: main
     description: |
-      Branch to use as a reference when determining modified files. 
+      Branch to use as a reference when determining modified files.
       By default, the main branch will be used.
-      If the "strategy" is set to modified, this parameter must also be set.
+      If the strategy is set to "modified", this parameter must also be set.
 steps:
   - checkout
   - run:

--- a/src/scripts/lint.sh
+++ b/src/scripts/lint.sh
@@ -4,8 +4,19 @@ redtext() {
   echo -e "\033[0;31m$1\033[0m"
 }
 
+# $1: glob
+# $2: config
+# $3: base_dir or files
+sync_and_run_vale() {
+  set -x
+  vale sync
+  vale --glob="$1" --config="$2" "$3"
+  set +x
+}
+
 VALE_EVAL_CLI_CONFIG="$(eval echo "$VALE_EVAL_CLI_CONFIG")"
 VALE_STR_CLI_GLOB="$(circleci env subst "$VALE_STR_CLI_GLOB")"
+VALE_STR_REFERENCE_BRANCH="$(circleci env subst "$VALE_STR_REFERENCE_BRANCH")"
 
 VALE_EVAL_CLI_BASE_DIR="$(eval echo "$VALE_EVAL_CLI_BASE_DIR")"
 VALE_EVAL_CLI_BASE_DIR="${VALE_EVAL_CLI_BASE_DIR/\~/$HOME}"
@@ -21,7 +32,16 @@ if [[ ! -f "$VALE_EVAL_CLI_CONFIG" ]]; then
   '
   exit 1
 fi
-set -x
-vale sync
-vale --glob="$VALE_STR_CLI_GLOB" --config="$VALE_EVAL_CLI_CONFIG" "$VALE_EVAL_CLI_BASE_DIR"
-set +x
+
+if [[ "$VALE_ENUM_STRATEGY" == "all" ]]; then
+  sync_and_run_vale "$VALE_STR_CLI_GLOB" "$VALE_EVAL_CLI_CONFIG" "$VALE_EVAL_CLI_BASE_DIR"
+elif [[ "$VALE_ENUM_STRATEGY" == "modified" ]]; then
+  echo "Checking for modified files..."
+  modified_files="$(git diff --name-only "$VALE_STR_REFERENCE_BRANCH")"
+  [ -z "$modified_files" ] && { echo "No modified files found"; exit 0; }
+  files_space_delimited="$(echo "$modified_files" | tr '\n' ' ')"
+  sync_and_run_vale "$VALE_STR_CLI_GLOB" "$VALE_EVAL_CLI_CONFIG" "$files_space_delimited"
+else
+  echo "Invalid strategy: $VALE_ENUM_STRATEGY"
+  exit 1
+fi

--- a/src/scripts/lint.sh
+++ b/src/scripts/lint.sh
@@ -36,10 +36,14 @@ fi
 if [[ "$VALE_ENUM_STRATEGY" == "all" ]]; then
   sync_and_run_vale "$VALE_STR_CLI_GLOB" "$VALE_EVAL_CLI_CONFIG" "$VALE_EVAL_CLI_BASE_DIR"
 elif [[ "$VALE_ENUM_STRATEGY" == "modified" ]]; then
+  echo "Installing git..."
+  command -v git &>/dev/null || { apk add git; }
+
   echo "Checking for modified files..."
   modified_files="$(git diff --name-only "$VALE_STR_REFERENCE_BRANCH")"
-  [ -z "$modified_files" ] && { echo "No modified files found"; exit 0; }
   files_space_delimited="$(echo "$modified_files" | tr '\n' ' ')"
+
+  echo "Running vale on modified files..."
   sync_and_run_vale "$VALE_STR_CLI_GLOB" "$VALE_EVAL_CLI_CONFIG" "$files_space_delimited"
 else
   echo "Invalid strategy: $VALE_ENUM_STRATEGY"

--- a/src/scripts/lint.sh
+++ b/src/scripts/lint.sh
@@ -6,11 +6,12 @@ redtext() {
 
 # $1: glob
 # $2: config
-# $3: base_dir or files
+# $3: files
 sync_and_run_vale() {
   set -x
   vale sync
-  vale --glob="$1" --config="$2" "$3"
+  # shellcheck disable=SC2086
+  vale --glob="$1" --config="$2" $3  # No quotes around $3
   set +x
 }
 
@@ -21,7 +22,7 @@ VALE_STR_REFERENCE_BRANCH="$(circleci env subst "$VALE_STR_REFERENCE_BRANCH")"
 VALE_EVAL_CLI_BASE_DIR="$(eval echo "$VALE_EVAL_CLI_BASE_DIR")"
 VALE_EVAL_CLI_BASE_DIR="${VALE_EVAL_CLI_BASE_DIR/\~/$HOME}"
 
-if [[ ! -f "$VALE_EVAL_CLI_CONFIG" ]]; then
+if [ ! -f "$VALE_EVAL_CLI_CONFIG" ]; then
   redtext "No configuration file found at $VALE_EVAL_CLI_CONFIG"
   echo "To get started, you'll need a configuration file (.vale.ini)"
   echo "Create a config file, or modify the 'config' parameter for this job"
@@ -33,18 +34,19 @@ if [[ ! -f "$VALE_EVAL_CLI_CONFIG" ]]; then
   exit 1
 fi
 
-if [[ "$VALE_ENUM_STRATEGY" == "all" ]]; then
+if [ "$VALE_ENUM_STRATEGY" = "all" ]; then
   sync_and_run_vale "$VALE_STR_CLI_GLOB" "$VALE_EVAL_CLI_CONFIG" "$VALE_EVAL_CLI_BASE_DIR"
-elif [[ "$VALE_ENUM_STRATEGY" == "modified" ]]; then
+elif [ "$VALE_ENUM_STRATEGY" = "modified" ]; then
   echo "Installing git..."
-  command -v git &>/dev/null || { apk add git; }
+  command -v git > /dev/null 2>&1 || { apk add git; }
 
   echo "Checking for modified files..."
   modified_files="$(git diff --name-only "$VALE_STR_REFERENCE_BRANCH")"
-  files_space_delimited="$(echo "$modified_files" | tr '\n' ' ')"
+  echo "$modified_files"
 
+  modified_files_space_separated=$(echo "$modified_files" | tr '\n' ' ')
   echo "Running vale on modified files..."
-  sync_and_run_vale "$VALE_STR_CLI_GLOB" "$VALE_EVAL_CLI_CONFIG" "$files_space_delimited"
+  sync_and_run_vale "$VALE_STR_CLI_GLOB" "$VALE_EVAL_CLI_CONFIG" "$modified_files_space_separated"
 else
   echo "Invalid strategy: $VALE_ENUM_STRATEGY"
   exit 1


### PR DESCRIPTION
## Description

Currently, the orb will lint every file in the repository. This PR allows users to lint only files modified in the current branch.

## Changes

- Include a `strategy` parameter so users can pick between linting every file or only modified files.
- Add a `reference_branch` parameter so users can specify which branch should be used as the baseline for comparing the changes.
- Modify the script to install `git` if users pick the `modified` strategy, as it doesn't ship with the job's image.