### PR TITLE
Allowing Vale version to be specified in the `lint` job

### DIFF
--- a/src/examples/lint_specify_vale_version.yml
+++ b/src/examples/lint_specify_vale_version.yml
@@ -1,0 +1,14 @@
+description: >
+  When using the `vale/lint` job you can also specify the Vale version you wish to use. 
+usage:
+  version: 2.1
+  orbs:
+    vale: circleci/vale@1.2.1
+  workflows:
+    publish-docs:
+      jobs:
+        - vale/lint:
+            name: lint docs
+            strategy: all
+            glob: "[!.]*.{md,adoc}"
+            vale_version: v3.6.1

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -1,7 +1,9 @@
 description: >
   Lint your markdown, AsciiDoc, reStructuredText, and more.
 
-executor: default
+executor:
+  name: default
+  tag: << parameters.vale_version >>
 
 parameters:
   glob:
@@ -31,6 +33,13 @@ parameters:
       Branch to use as a reference when determining modified files.
       By default, the main branch will be used.
       If the strategy is set to "modified", this parameter must also be set.
+  vale_version:
+    type: string
+    default: latest
+    description: |
+      Vale version to use.
+      The value must be specified as "v<version_number>".
+      For example: v3.6.1
 steps:
   - checkout
   - run:


### PR DESCRIPTION
Adding the “pass-through” parameter `vale_version` to the orb's lint job so users can specify the Vale version they want to use.

Under the hood the value of the `vale_version` parameter is passed through to the orb's `default` executor's `tag` parameter.