### PR TITLE
Use three-dot diff to only lint files changed in current branch

### DIFF
--- a/src/scripts/lint.sh
+++ b/src/scripts/lint.sh
@@ -53,7 +53,7 @@ elif [ "$VALE_ENUM_STRATEGY" = "modified" ]; then
           ;;
       esac
   done <<EOF
-  $(git diff --name-only --diff-filter=d "$VALE_STR_REFERENCE_BRANCH")
+  $(git diff --name-only --diff-filter=d "$VALE_STR_REFERENCE_BRANCH"...HEAD)
 EOF
   
   echo "$FILES"


### PR DESCRIPTION
Fix: Use three-dot diff to only lint files changed in current branch

Changes git diff from two-dot to three-dot syntax when using the 'modified' strategy. This ensures Vale only lints files that were actually changed in the current branch, rather than all differences between the feature branch and the reference branch.                                                            
                                                                                                                     
Problem: When a feature branch falls behind the reference branch (e.g., main), the two-dot diff (main vs. feature) includes files that were changed in main AFTER the feature branch was created. This causes Vale to lint files the contributor never touched, leading to confusion.                                                 

Solution: Use three-dot syntax (main...HEAD) which compares against the merge base, showing only files changed in the current branch since it diverged from the reference branch. 